### PR TITLE
⚡️ perf(gateway): enable TCP_NODELAY on relay sockets (disable Nagle)

### DIFF
--- a/src/gateway/BaseGateway.ts
+++ b/src/gateway/BaseGateway.ts
@@ -175,6 +175,7 @@ export abstract class BaseGateway extends EventEmitter {
       setKeepAliveInterval(socket, this.options.keepAlive * 1000);
       setKeepAliveProbes(socket, Math.max(this.options.keepAliveRetries, 1));
     }
+    socket.setNoDelay(true);
     socket.once("close", () => {
       socket.removeAllListeners();
     });


### PR DESCRIPTION
## Summary

`BaseGateway._onConnection` sets each accepted socket's timeout and TCP keep-alive but **never calls `socket.setNoDelay(true)`**, so Nagle's algorithm stays enabled on both hooked-up relay sockets. This one-line change disables Nagle on the relay path.

```ts
setKeepAliveProbes(socket, Math.max(this.options.keepAliveRetries, 1));
}
socket.setNoDelay(true);   // <-- added
```

## Mechanism

For interactive VNC traffic (bursty, sub-MSS mouse/keyboard writes), Nagle interacts with the peer's **delayed-ACK** timer: when several small writes are issued back-to-back before an ACK returns, Nagle holds the later segments until the ~40 ms delayed-ACK timer fires — a ~40 ms per-exchange stall. `setNoDelay(true)` removes that hold.

The effect is **latency-specific**: the bulk relay path writes chunks larger than MSS, which Nagle never coalesces, so throughput is untouched.

## Correctness

- The change lives in the shared `BaseGateway._onConnection`, so it applies to **both** relay sockets. An ablation showed only the *egress* (writing) socket's Nagle state governs a given direction's latency, so covering both directions requires setting it on both sockets — which the shared handler does.
- `setNoDelay` is a standard, side-effect-free socket option; no behavioral change beyond disabling write coalescing.
- Build + lint pass (`npm run build`, `npx eslint "src/**/*.ts"`). The repo ships no test files, so build+lint is the gate.

## Measured result

Validated by a [Nous](https://github.com/) hypothesis-driven campaign on Linux loopback (10 pre-registered seeds, rehearsal + real iterations):

| Arm | Metric | Baseline (Nagle on) | Treatment (`setNoDelay`) | Result |
|-----|--------|--------------------:|-------------------------:|--------|
| H-main | interactive p50 RTT (WPE=4, 1 B) | ~41.2 ms | ~0.090 ms | **~457× faster**, 10/10 seeds |
| H-control-negative | bulk throughput (64 KiB chunks, 50 MB) | 726 MB/s | 756 MB/s | +4.1% median, within noise — **no regression** |
| H-ablation | which socket governs latency | server-only ~41 ms | client-only ~0.090 ms | egress socket dominates |
| H-robustness | payloads {1, 16, 64} B | ~41.5 ms | ~0.091 ms | size-invariant |
| H-dose-response | benefit vs. inter-write gap | — | — | ~41 ms at gap=0 → <1 ms by gap≥20 ms |

The benefit is conditional on write cadence: it appears when ≥4 sub-MSS writes are issued back-to-back within an exchange (as interactive VNC input tends to produce) and vanishes once writes are spaced ≥20 ms apart.

## Relationship to other work

Complementary to **#479** (event-driven handshake read): that change cut connection *setup* latency; this one cuts *steady-state* per-exchange latency on the relay path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)